### PR TITLE
Refactor notifications and add unitary tests

### DIFF
--- a/src/sdi-forced-refresh-time-constants.h
+++ b/src/sdi-forced-refresh-time-constants.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2024 Canonical Ltd
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#define SECONDS_IN_A_DAY 86400
+#define SECONDS_IN_AN_HOUR 3600
+#define SECONDS_IN_A_MINUTE 60
+
+// Time constants for forced refresh notifications.
+#define TIME_TO_SHOW_REMAINING_TIME_BEFORE_FORCED_REFRESH (SECONDS_IN_A_DAY * 3)
+#define TIME_TO_SHOW_ALERT_BEFORE_FORCED_REFRESH (SECONDS_IN_AN_HOUR * 19)

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -23,6 +23,7 @@
 #include <glib/gi18n.h>
 #include <libnotify/notify.h>
 
+#include "io.snapcraft.PrivilegedDesktopLauncher.h"
 #include "sdi-forced-refresh-time-constants.h"
 #include "sdi-helpers.h"
 #include "sdi-notify.h"
@@ -36,13 +37,6 @@ struct _SdiNotify {
 };
 
 G_DEFINE_TYPE(SdiNotify, sdi_notify, G_TYPE_OBJECT)
-
-static GTimeSpan get_remaining_time_in_seconds(SnapdSnap *snap) {
-  GDateTime *proceed_time = snapd_snap_get_proceed_time(snap);
-  g_autoptr(GDateTime) now = g_date_time_new_now_local();
-  GTimeSpan difference = g_date_time_difference(proceed_time, now) / 1000000;
-  return difference;
-}
 
 static gboolean launch_desktop(GApplication *app, const gchar *desktop_file) {
   g_autofree gchar *full_desktop_path = NULL;
@@ -198,7 +192,6 @@ static void app_launch_updated(NotifyNotification *notification, char *action,
       g_strdup_printf("app-launch-updated %s", data->desktop);
   g_signal_emit_by_name(data->self, "notification-closed", param);
 #endif
-  LaunchUpdatedApp *data = (LaunchUpdatedApp *)user_data;
   launch_desktop(data->self->application, (const gchar *)data->desktop);
   g_object_unref(notification);
 }

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -15,9 +15,7 @@
  *
  */
 
-#define SECONDS_IN_A_DAY 86400
-#define SECONDS_IN_AN_HOUR 3600
-#define SECONDS_IN_A_MINUTE 60
+// .desktop files for snap store.
 #define SNAP_STORE "snap-store_snap-store.desktop"
 #define SNAP_STORE_UPDATES "snap-store_show-updates.desktop"
 
@@ -25,12 +23,9 @@
 #include <glib/gi18n.h>
 #include <libnotify/notify.h>
 
-#include "io.snapcraft.PrivilegedDesktopLauncher.h"
+#include "sdi-forced-refresh-time-constants.h"
 #include "sdi-helpers.h"
 #include "sdi-notify.h"
-
-#define TIME_TO_SHOW_REMAINING_TIME_BEFORE_FORCED_REFRESH (SECONDS_IN_A_DAY * 3)
-#define TIME_TO_SHOW_ALERT_BEFORE_FORCED_REFRESH (SECONDS_IN_AN_HOUR * 19)
 
 enum { PROP_APPLICATION = 1, PROP_LAST };
 
@@ -75,6 +70,9 @@ static gboolean launch_desktop(GApplication *app, const gchar *desktop_file) {
 }
 
 static void show_updates(SdiNotify *self) {
+#ifdef DEBUG_TESTS
+  g_signal_emit_by_name(self, "notification-closed", "show-updates");
+#endif
   if (!launch_desktop(self->application, SNAP_STORE_UPDATES)) {
     launch_desktop(self->application, SNAP_STORE);
   }
@@ -95,18 +93,9 @@ static void sdi_notify_action_ignore(GActionGroup *action_group,
   for (gsize i = 0; i < len; i++) {
     g_signal_emit_by_name(self, "ignore-snap-event", apps[i]);
   }
-}
-
-static GVariant *get_snap_list(GSList *snaps) {
-  if (snaps == NULL)
-    return NULL;
-  g_autoptr(GVariantBuilder) builder =
-      g_variant_builder_new(G_VARIANT_TYPE("as"));
-  for (; snaps != NULL; snaps = snaps->next) {
-    SnapdSnap *snap = (SnapdSnap *)snaps->data;
-    g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
-  }
-  return g_variant_ref_sink(g_variant_builder_end(builder));
+#ifdef DEBUG_TESTS
+  g_signal_emit_by_name(self, "notification-closed", "ignore-snaps");
+#endif
 }
 
 // Currently, due to the way Snapd creates the .desktop files, the notifications
@@ -115,6 +104,18 @@ static GVariant *get_snap_list(GSList *snaps) {
 // default, we use libnotify. This problem is being tackled by the snapd people,
 // so, in the future, GNotify would be the prefered choice.
 #ifndef USE_GNOTIFY
+
+static GVariant *get_snap_list(GListModel *snaps) {
+  if (snaps == NULL)
+    return NULL;
+  g_autoptr(GVariantBuilder) builder =
+      g_variant_builder_new(G_VARIANT_TYPE("as"));
+  for (int i = 0; i < g_list_model_get_n_items(snaps); i++) {
+    g_autoptr(SnapdSnap) snap = g_list_model_get_item(snaps, i);
+    g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
+  }
+  return g_variant_ref_sink(g_variant_builder_end(builder));
+}
 
 static gchar *get_icon_name_from_gicon(GIcon *icon) {
   if (icon == NULL) {
@@ -165,15 +166,15 @@ typedef struct {
   gchar *desktop;
 } LaunchUpdatedApp;
 
-LaunchUpdatedApp *launch_updated_app_new(SdiNotify *self,
-                                         const gchar *desktop) {
+static LaunchUpdatedApp *launch_updated_app_new(SdiNotify *self,
+                                                const gchar *desktop) {
   LaunchUpdatedApp *data = g_malloc0(sizeof(LaunchUpdatedApp));
   data->self = g_object_ref(self);
   data->desktop = g_strdup(desktop);
   return data;
 }
 
-void launch_updated_app_free(void *user_data) {
+static void launch_updated_app_free(void *user_data) {
   LaunchUpdatedApp *data = (LaunchUpdatedApp *)user_data;
   g_object_unref(data->self);
   g_free(data->desktop);
@@ -183,20 +184,28 @@ void launch_updated_app_free(void *user_data) {
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(LaunchUpdatedApp, launch_updated_app_free)
 
 static void app_close_notification(NotifyNotification *notification,
-                                   char *action, gpointer user_data) {
+                                   char *action, SdiNotify *self) {
+#ifdef DEBUG_TESTS
+  g_signal_emit_by_name(self, "notification-closed", "close-notification");
+#endif
   g_object_unref(notification);
 }
 
 static void app_launch_updated(NotifyNotification *notification, char *action,
-                               gpointer user_data) {
+                               LaunchUpdatedApp *data) {
+#ifdef DEBUG_TESTS
+  g_autofree gchar *param =
+      g_strdup_printf("app-launch-updated %s", data->desktop);
+  g_signal_emit_by_name(data->self, "notification-closed", param);
+#endif
   LaunchUpdatedApp *data = (LaunchUpdatedApp *)user_data;
   launch_desktop(data->self->application, (const gchar *)data->desktop);
   g_object_unref(notification);
 }
 
 static void app_show_updates(NotifyNotification *notification, char *action,
-                             gpointer user_data) {
-  show_updates((SdiNotify *)user_data);
+                             SdiNotify *self) {
+  show_updates(self);
   g_object_unref(notification);
 }
 
@@ -210,7 +219,7 @@ static void app_ignore_snaps_notification(NotifyNotification *notification,
 static void show_pending_update_notification(SdiNotify *self,
                                              const gchar *title,
                                              const gchar *body, GIcon *icon,
-                                             GSList *snaps,
+                                             GListModel *snaps,
                                              gboolean allow_to_ignore) {
   g_autofree gchar *icon_name = get_icon_name_from_gicon(icon);
   // Don't use g_autoptr because it must survive for the actions
@@ -222,15 +231,16 @@ static void show_pending_update_notification(SdiNotify *self,
                                  g_variant_new_string(icon_name));
   }
   notify_notification_add_action(notification, "app.show-updates",
-                                 _("Show updates"), app_show_updates,
+                                 _("Show updates"),
+                                 (NotifyActionCallback)app_show_updates,
                                  g_object_ref(self), g_object_unref);
   // This is the default action, the one executed when the user clicks on the
   // notification itself. It has no button, so the _("Show updates") text is
   // really unnecesary. It's added just in case in a future notifications do
   // use it for... whatever... a popup, for example.
   notify_notification_add_action(notification, "default", _("Show updates"),
-                                 app_show_updates, g_object_ref(self),
-                                 g_object_unref);
+                                 (NotifyActionCallback)app_show_updates,
+                                 g_object_ref(self), g_object_unref);
   if (allow_to_ignore) {
     g_autoptr(GVariant) snap_list = get_snap_list(snaps);
     /// TRANSLATORS: Text for a button in a notification. Pressing it
@@ -264,12 +274,13 @@ static void update_complete_notification(SdiNotify *self, const gchar *title,
     /// after a snap has been refreshed. Pressing it will close the
     /// notification.
     notify_notification_add_action(notification, "default", _("Close"),
-                                   app_close_notification, NULL, NULL);
+                                   (NotifyActionCallback)app_close_notification,
+                                   g_object_ref(self), g_object_unref);
   } else {
     LaunchUpdatedApp *data = launch_updated_app_new(self, desktop);
     notify_notification_add_action(notification, "default", _("Close"),
-                                   app_launch_updated, data,
-                                   launch_updated_app_free);
+                                   (NotifyActionCallback)app_launch_updated,
+                                   data, launch_updated_app_free);
   }
   notify_notification_show(notification, NULL);
 }
@@ -279,7 +290,7 @@ static void update_complete_notification(SdiNotify *self, const gchar *title,
 static void show_pending_update_notification(SdiNotify *self,
                                              const gchar *title,
                                              const gchar *body, GIcon *icon,
-                                             GSList *snaps,
+                                             GListModel *snaps,
                                              gboolean allow_to_ignore) {
   g_autoptr(GNotification) notification = g_notification_new(title);
   g_notification_set_body(notification, body);
@@ -294,8 +305,8 @@ static void show_pending_update_notification(SdiNotify *self,
   if (allow_to_ignore) {
     g_autoptr(GVariantBuilder) builder =
         g_variant_builder_new(G_VARIANT_TYPE("as"));
-    for (; snaps != NULL; snaps = snaps->next) {
-      SnapdSnap *snap = (SnapdSnap *)snaps->data;
+    for (int i = 0; i != g_list_model_get_n_items(snaps); i++) {
+      g_autoptr(SnapdSnap) snap = g_list_model_get_item(snaps, i);
       g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
     }
     GVariant *values = g_variant_ref_sink(g_variant_builder_end(builder));
@@ -323,8 +334,10 @@ static void update_complete_notification(SdiNotify *self, const gchar *title,
 }
 #endif
 
-static void notify_pending_refresh_forced(SdiNotify *self, SnapdSnap *snap,
-                                          gboolean allow_to_ignore) {
+void sdi_notify_pending_refresh_forced(SdiNotify *self, SnapdSnap *snap,
+                                       GTimeSpan remaining_time,
+                                       gboolean allow_to_ignore,
+                                       gpointer data) {
   g_return_if_fail(SDI_IS_NOTIFY(self));
   g_return_if_fail(snap != NULL);
 
@@ -337,9 +350,7 @@ static void notify_pending_refresh_forced(SdiNotify *self, SnapdSnap *snap,
 
   g_autofree gchar *title = NULL;
 
-  GTimeSpan difference = get_remaining_time_in_seconds(snap);
-
-  if (difference > SECONDS_IN_A_DAY) {
+  if (remaining_time > SECONDS_IN_A_DAY) {
     /// TRANSLATORS: The %s is the name of a snap that is currently running,
     /// and it will be closed and updated in %ld days if the user doesn't
     /// close it before. This is shown after the user has been notified several
@@ -347,19 +358,19 @@ static void notify_pending_refresh_forced(SdiNotify *self, SnapdSnap *snap,
     /// hasn't closed it, to inform they that there is a time limit before the
     /// snap is forced to quit to refresh it.
     title = g_strdup_printf(_("%s will quit and update in %ld days"), name,
-                            difference / SECONDS_IN_A_DAY);
-  } else if (difference > SECONDS_IN_AN_HOUR) {
+                            remaining_time / SECONDS_IN_A_DAY);
+  } else if (remaining_time > SECONDS_IN_AN_HOUR) {
     /// TRANSLATORS: The %s is the name of a snap that is currently running,
     /// and it will be closed and updated in %ld hours if the user doesn't
     /// close it before.
     title = g_strdup_printf(_("%s will quit and update in %ld hours"), name,
-                            difference / SECONDS_IN_AN_HOUR);
+                            remaining_time / SECONDS_IN_AN_HOUR);
   } else {
     /// TRANSLATORS: The %s is the name of a snap that is currently running,
     /// and it will be closed and updated in %ld minutes if the user doesn't
     /// close it before.
     title = g_strdup_printf(_("%s will quit and update in %ld minutes"), name,
-                            difference / SECONDS_IN_A_MINUTE);
+                            remaining_time / SECONDS_IN_A_MINUTE);
   }
 
   GIcon *icon = NULL;
@@ -367,28 +378,13 @@ static void notify_pending_refresh_forced(SdiNotify *self, SnapdSnap *snap,
     icon = g_app_info_get_icon(app_info);
   }
 
+  g_autoptr(GListStore) snap_list = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snap_list, snap);
   /// TRANSLATORS: This message is shown below the "%s will quit and update
   /// in..." message.
   show_pending_update_notification(
       self, title, _("Save your progress and quit now to prevent data loss."),
-      icon, g_slist_append(NULL, snap), allow_to_ignore);
-}
-
-gboolean sdi_notify_check_forced_refresh(SdiNotify *self, SnapdSnap *snap,
-                                         SdiSnap *snap_data) {
-  // Check if we have to show a notification with the time when it will be
-  // force-refreshed
-  GTimeSpan next_refresh = get_remaining_time_in_seconds(snap);
-  if ((next_refresh <= TIME_TO_SHOW_REMAINING_TIME_BEFORE_FORCED_REFRESH) &&
-      (!sdi_snap_get_ignored(snap_data))) {
-    notify_pending_refresh_forced(self, snap, TRUE);
-    return TRUE;
-  } else if (next_refresh <= TIME_TO_SHOW_ALERT_BEFORE_FORCED_REFRESH) {
-    // If the remaining time is less than this, force a notification.
-    notify_pending_refresh_forced(self, snap, FALSE);
-    return TRUE;
-  }
-  return FALSE;
+      icon, G_LIST_MODEL(snap_list), allow_to_ignore);
 }
 
 static gchar *get_name_from_snap(SnapdSnap *snap) {
@@ -425,7 +421,8 @@ static gchar *build_body_message_for_three_refreshes(SnapdSnap *snap0,
                          snap_name0, snap_name1, snap_name2);
 }
 
-void sdi_notify_pending_refresh(SdiNotify *self, GSList *snaps) {
+void sdi_notify_pending_refresh(SdiNotify *self, GListModel *snaps,
+                                gpointer data) {
   g_return_if_fail(SDI_IS_NOTIFY(self));
   g_return_if_fail(snaps != NULL);
 
@@ -434,15 +431,16 @@ void sdi_notify_pending_refresh(SdiNotify *self, GSList *snaps) {
   g_autoptr(GAppInfo) app_info = NULL;
   g_autoptr(GDesktopAppInfo) app_info2 = NULL;
 
-  guint n_snaps = g_slist_length(snaps);
+  guint n_snaps = g_list_model_get_n_items(snaps);
 
   GIcon *icon = NULL;
   if (n_snaps == 1) {
-    g_autofree gchar *snap_name = get_name_from_snap((SnapdSnap *)snaps->data);
+    g_autoptr(SnapdSnap) snap0 = g_list_model_get_item(snaps, 0);
+    g_autofree gchar *snap_name = get_name_from_snap(snap0);
     /// TRANSLATORS: The %s is the name of a snap that has an update available.
     title = g_strdup_printf(_("Update available for %s"), snap_name);
     body = g_strdup(_("Quit the app to update it now."));
-    app_info = sdi_get_desktop_file_from_snap((SnapdSnap *)snaps->data);
+    app_info = sdi_get_desktop_file_from_snap(snap0);
     if (app_info != NULL) {
       icon = g_app_info_get_icon(app_info);
     }
@@ -455,15 +453,17 @@ void sdi_notify_pending_refresh(SdiNotify *self, GSList *snaps) {
     title = g_strdup_printf(ngettext("Update available for %d app",
                                      "Updates available for %d apps", n_snaps),
                             n_snaps);
+    g_autoptr(SnapdSnap) snap0 = g_list_model_get_item(snaps, 0);
+    g_autoptr(SnapdSnap) snap1 = g_list_model_get_item(snaps, 1);
+    // snap2 will be NULL if the number of items is less than three,
+    // so it's not a problem to do this.
+    g_autoptr(SnapdSnap) snap2 = g_list_model_get_item(snaps, 2);
     switch (n_snaps) {
     case 2:
-      body = build_body_message_for_two_refreshes(
-          (SnapdSnap *)snaps->data, (SnapdSnap *)snaps->next->data);
+      body = build_body_message_for_two_refreshes(snap0, snap1);
       break;
     case 3:
-      body = build_body_message_for_three_refreshes(
-          (SnapdSnap *)snaps->data, (SnapdSnap *)snaps->next->data,
-          (SnapdSnap *)snaps->next->next->data);
+      body = build_body_message_for_three_refreshes(snap0, snap1, snap2);
       break;
     default:
       /// TRANSLATORS: This message is used when there are four or more pending
@@ -482,7 +482,7 @@ void sdi_notify_pending_refresh(SdiNotify *self, GSList *snaps) {
 }
 
 void sdi_notify_refresh_complete(SdiNotify *self, SnapdSnap *snap,
-                                 const gchar *snap_name) {
+                                 const gchar *snap_name, gpointer data) {
   g_return_if_fail(SDI_IS_NOTIFY(self));
   g_return_if_fail((snap != NULL) || (snap_name != NULL));
 
@@ -508,11 +508,6 @@ void sdi_notify_refresh_complete(SdiNotify *self, SnapdSnap *snap,
 
   update_complete_notification(self, title, _("You can reopen it now."), icon,
                                "update-complete", desktop);
-}
-
-GApplication *sdi_notify_get_application(SdiNotify *self) {
-  g_return_val_if_fail(SDI_IS_NOTIFY(self), NULL);
-  return self->application;
 }
 
 static void set_actions(SdiNotify *self) {
@@ -579,7 +574,11 @@ static void sdi_notify_dispose(GObject *object) {
   G_OBJECT_CLASS(sdi_notify_parent_class)->dispose(object);
 }
 
-void sdi_notify_init(SdiNotify *self) {}
+void sdi_notify_init(SdiNotify *self) {
+#ifndef USE_GNOTIFY
+  notify_init("snapd-desktop-integration-test_snapd-desktop-integration-test");
+#endif
+}
 
 void sdi_notify_class_init(SdiNotifyClass *klass) {
   GObjectClass *gobject_class = G_OBJECT_CLASS(klass);
@@ -597,6 +596,11 @@ void sdi_notify_class_init(SdiNotifyClass *klass) {
 
   g_signal_new("ignore-snap-event", G_TYPE_FROM_CLASS(klass), G_SIGNAL_RUN_LAST,
                0, NULL, NULL, NULL, G_TYPE_NONE, 1, G_TYPE_STRING);
+#ifdef DEBUG_TESTS
+  g_signal_new("notification-closed", G_TYPE_FROM_CLASS(klass),
+               G_SIGNAL_RUN_LAST, 0, NULL, NULL, NULL, G_TYPE_NONE, 1,
+               G_TYPE_STRING);
+#endif
 }
 
 SdiNotify *sdi_notify_new(GApplication *application) {

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -298,7 +298,7 @@ static void show_pending_update_notification(SdiNotify *self,
   if (allow_to_ignore) {
     g_autoptr(GVariantBuilder) builder =
         g_variant_builder_new(G_VARIANT_TYPE("as"));
-    for (int i = 0; i != g_list_model_get_n_items(snaps); i++) {
+    for (int i = 0; i < g_list_model_get_n_items(snaps); i++) {
       g_autoptr(SnapdSnap) snap = g_list_model_get_item(snaps, i);
       g_variant_builder_add(builder, "s", snapd_snap_get_name(snap));
     }

--- a/src/sdi-notify.h
+++ b/src/sdi-notify.h
@@ -29,14 +29,14 @@ G_DECLARE_FINAL_TYPE(SdiNotify, sdi_notify, SDI, NOTIFY, GObject)
 
 SdiNotify *sdi_notify_new(GApplication *application);
 
-GApplication *sdi_notify_get_application(SdiNotify *notify);
-
-void sdi_notify_pending_refresh(SdiNotify *notify, GSList *snaps);
+void sdi_notify_pending_refresh(SdiNotify *notify, GListModel *snaps,
+                                gpointer data);
 
 void sdi_notify_refresh_complete(SdiNotify *notify, SnapdSnap *snap,
-                                 const gchar *snap_name);
+                                 const gchar *snap_name, gpointer data);
 
-gboolean sdi_notify_check_forced_refresh(SdiNotify *notify, SnapdSnap *snap,
-                                         SdiSnap *snap_data);
+void sdi_notify_pending_refresh_forced(SdiNotify *self, SnapdSnap *snap,
+                                       GTimeSpan remaining_time,
+                                       gboolean allow_to_ignore, gpointer data);
 
 G_END_DECLS

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -705,7 +705,6 @@ void sdi_refresh_monitor_class_init(SdiRefreshMonitorClass *klass) {
 }
 
 SdiRefreshMonitor *sdi_refresh_monitor_new(GApplication *application) {
-
   SdiRefreshMonitor *self = g_object_new(SDI_TYPE_REFRESH_MONITOR, NULL);
   self->application = g_object_ref(application);
   g_autofree gchar *unity_object =

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -93,6 +93,13 @@ static void free_progress_task_data(void *data) {
   g_free(data);
 }
 
+static GTimeSpan get_remaining_time_in_seconds(SnapdSnap *snap) {
+  GDateTime *proceed_time = snapd_snap_get_proceed_time(snap);
+  g_autoptr(GDateTime) now = g_date_time_new_now_local();
+  GTimeSpan difference = g_date_time_difference(proceed_time, now) / 1000000;
+  return difference;
+}
+
 static GPtrArray *get_desktop_filenames_for_snap(const gchar *snap_name) {
   g_autoptr(GDir) desktop_folder =
       g_dir_open("/var/lib/snapd/desktop/applications", 0, NULL);
@@ -499,7 +506,7 @@ static gboolean notify_check_forced_refresh(SdiNotify *self, SnapdSnap *snap,
                                             SdiSnap *snap_data) {
   // Check if we have to show a notification with the time when it will be
   // force-refreshed
-  GTimeSpan next_refresh = sdi_get_remaining_time_in_seconds(snap);
+  GTimeSpan next_refresh = get_remaining_time_in_seconds(snap);
   if ((next_refresh <= TIME_TO_SHOW_REMAINING_TIME_BEFORE_FORCED_REFRESH) &&
       (!sdi_snap_get_ignored(snap_data))) {
     g_signal_emit_by_name(self, "notify-pending-refresh-forced", snap,

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -676,7 +676,7 @@ void sdi_refresh_monitor_init(SdiRefreshMonitor *self) {
 }
 
 /**
- * This CB must be called whenever the user presses the "Don't remind me
+ * This callback must be called whenever the user presses the "Don't remind me
  * anymore" button in a notification. It will receive one snap name, so if
  * the notification has several snaps, it must call this method once for each
  * one.

--- a/src/sdi-refresh-monitor.h
+++ b/src/sdi-refresh-monitor.h
@@ -31,10 +31,7 @@ SdiRefreshMonitor *sdi_refresh_monitor_new(GApplication *application);
 
 gboolean sdi_refresh_monitor_start(SdiRefreshMonitor *monitor, GError **error);
 
-SdiSnap *
-sdi_refresh_monitor_begin_application_refresh(SdiRefreshMonitor *monitor,
-                                              const gchar *snap_name);
-
-GApplication *sdi_refresh_monitor_get_application(SdiRefreshMonitor *monitor);
+void sdi_refresh_monitor_ignore_snap_cb(SdiRefreshMonitor *self,
+                                        const gchar *snap_name, gpointer data);
 
 G_END_DECLS

--- a/tests/data/icon1.svg
+++ b/tests/data/icon1.svg
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="128mm"
+   height="128mm"
+   viewBox="0 0 128 128"
+   version="1.1"
+   id="svg5"
+   inkscape:version="1.2.2 (b0a8486541, 2022-12-01)"
+   sodipodi:docname="icon1.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview7"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     showgrid="false"
+     inkscape:zoom="1.1893044"
+     inkscape:cx="190.86787"
+     inkscape:cy="230.38677"
+     inkscape:window-width="1920"
+     inkscape:window-height="1011"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs2">
+    <rect
+       x="108.07591"
+       y="110.68707"
+       width="263.46808"
+       height="262.63054"
+       id="rect400" />
+  </defs>
+  <g
+     inkscape:label="Capa 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#eed7cf;stroke:#000000;stroke-width:0.264583;stroke-linejoin:round"
+       id="path234"
+       cx="62.251774"
+       cy="62.668026"
+       r="49.511948" />
+    <text
+       xml:space="preserve"
+       transform="matrix(0.26458333,0,0,0.26458333,19.559621,5.2958997)"
+       id="text398"
+       style="font-size:192px;line-height:1.25;font-family:sans-serif;white-space:pre;shape-inside:url(#rect400)"><tspan
+         x="108.07617"
+         y="285.38354"
+         id="tspan429">T</tspan></text>
+  </g>
+</svg>

--- a/tests/data/meson.build
+++ b/tests/data/meson.build
@@ -1,0 +1,3 @@
+fs = import('fs')
+
+fs.copyfile('icon1.svg', 'icon1.svg')

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -10,3 +10,15 @@ test_executable = executable(
 )
 
 test('Tests', test_executable)
+
+sdi_notify_executable = executable(
+  'test-sdi-notify',
+  'test-sdi-notify.c',
+  '../src/sdi-notify.c',
+  '../src/sdi-helpers.c',
+  desktop_launcher_src,
+  dependencies: [gtk_dep, snapd_glib_dep, gio_dep, libnotify_dep],
+  c_args: ['-DDEBUG_TESTS']
+)
+
+subdir('data')

--- a/tests/test-sdi-notify.c
+++ b/tests/test-sdi-notify.c
@@ -1,0 +1,485 @@
+#include "../src/sdi-forced-refresh-time-constants.h"
+#include "../src/sdi-notify.h"
+#include "gtk/gtk.h"
+SdiNotify *notifier = NULL;
+
+typedef struct _testData {
+  const int test_number;
+  const char *title;
+  const char *description;
+  const char *actions;
+  const char *expected_results;
+  const void (*test_function)(struct _testData *);
+} TestData;
+
+gchar *tmpdirpath = NULL;
+
+/**
+ * Several help functions
+ */
+
+static void describe_test(TestData *test) {
+  g_assert(test != NULL);
+  g_assert(test->test_number != -1);
+  // g_print("\e[1;1H\e[2J"); // clear screen
+  g_print("\n\n\n\n");
+  g_print("Test number %d\n", test->test_number);
+  g_print("  Title: %s\n", test->title);
+  g_print("  Description: %s\n\n", test->description);
+  g_print("  Actions: %s\n", test->actions);
+  if (test->expected_results != NULL)
+    g_print("  Expected results: %s\n", test->expected_results);
+  g_print("Waiting for actions\n");
+}
+
+static gchar *get_data_path(gchar *resource_name) {
+  g_autofree gchar *path =
+      g_test_build_filename(G_TEST_BUILT, "data", resource_name, NULL);
+  return g_canonicalize_filename(path, NULL);
+}
+
+static gchar *create_desktop_file(gchar *name, gchar *visible_name,
+                                  gchar *icon) {
+  g_autofree gchar *filename = g_strdup_printf("%s.desktop", name);
+  gchar *desktop_path = g_build_path("/", tmpdirpath, filename, NULL);
+  FILE *f = fopen(desktop_path, "w");
+  g_assert(f != NULL);
+  fprintf(
+      f,
+      "[Desktop Entry]\nVersion=1.0\nType=Application\nExec=/usr/bin/xmessage "
+      "This is application %s\n",
+      visible_name);
+  if (visible_name != NULL) {
+    fprintf(f, "Name=%s\n", visible_name);
+  }
+  if (icon != NULL) {
+    fprintf(f, "Icon=%s\n", icon);
+  }
+  fclose(f);
+  return desktop_path;
+}
+
+static SnapdApp *create_app(gchar *name, gchar *desktop_file) {
+  return g_object_new(SNAPD_TYPE_APP, "name", name, "desktop-file",
+                      desktop_file, NULL);
+}
+
+static GPtrArray *add_app(GPtrArray *array, gchar *name, gchar *desktop_file) {
+  if (array == NULL) {
+    array = g_ptr_array_new_full(1, g_object_unref);
+  }
+  g_ptr_array_add(array, (gpointer)create_app(name, desktop_file));
+  return array;
+}
+
+static SnapdSnap *create_snap(gchar *snap_name, GPtrArray *apps) {
+  return g_object_new(SNAPD_TYPE_SNAP, "apps", apps, "name", snap_name, NULL);
+}
+
+static gchar *wait_for_notification_close_cb(GObject *self, gchar *param,
+                                             gpointer data) {
+  static GMainLoop *loop = NULL;
+  static gint sid = 0;
+  static gchar *result = NULL;
+  if (loop == NULL) {
+    // first call; connect the signal and wait
+    loop = g_main_loop_new(NULL, FALSE);
+    sid = g_signal_connect(notifier, "notification-closed",
+                           (GCallback)wait_for_notification_close_cb, NULL);
+    g_main_loop_run(loop);
+    g_signal_handler_disconnect(notifier, sid);
+    g_main_loop_unref(loop);
+    loop = NULL;
+    return g_steal_pointer(&result);
+  }
+  result = g_strdup(param);
+  g_main_loop_quit(loop);
+  return NULL;
+}
+
+static gchar *wait_for_notification_close() {
+  return wait_for_notification_close_cb(NULL, NULL, NULL);
+}
+
+/**
+ * Test functions
+ */
+
+void test_update_available_1(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file =
+      create_desktop_file("test1", "Test app 1", icon_path);
+
+  g_autoptr(GPtrArray) apps = add_app(NULL, "test_app1", desktop_file);
+  g_autoptr(SnapdSnap) snap = create_snap("test_snap1", apps);
+  g_autoptr(GListStore) snaps = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snaps, snap);
+  sdi_notify_pending_refresh(notifier, G_LIST_MODEL(snaps), NULL);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file); // delete desktop file
+  g_assert_cmpstr(result, ==, "show-updates");
+}
+
+void test_update_available_2(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file =
+      create_desktop_file("test2", "Test app 2", icon_path);
+
+  g_autoptr(GPtrArray) apps = add_app(NULL, "test_app2", desktop_file);
+  g_autoptr(SnapdSnap) snap = create_snap("test_snap2", apps);
+  g_autoptr(GListStore) snaps = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snaps, snap);
+  sdi_notify_pending_refresh(notifier, G_LIST_MODEL(snaps), NULL);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file); // delete desktop file
+  g_assert_cmpstr(result, ==, "show-updates");
+}
+
+static void test_ignore_event_cb(GObject *self, gchar *value, gpointer data) {
+  static gint counter = 0;
+  static gchar **string_list;
+  if (self == NULL) {
+    counter = 0;
+    string_list = (gchar **)data;
+    return;
+  }
+  g_assert_cmpstr(value, ==, string_list[counter]);
+  counter++;
+  gint *external_counter = (gint *)data;
+  *external_counter = counter;
+}
+
+void test_update_available_3(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file =
+      create_desktop_file("test3", "Test app 3", icon_path);
+
+  g_autoptr(GPtrArray) apps = add_app(NULL, "test_app3", desktop_file);
+  g_autoptr(SnapdSnap) snap = create_snap("test_snap3", apps);
+  g_autoptr(GListStore) snaps = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snaps, snap);
+  sdi_notify_pending_refresh(notifier, G_LIST_MODEL(snaps), NULL);
+
+  gint signal_counter = 0;
+  gchar *string_list[] = {"test_snap3"};
+  test_ignore_event_cb(NULL, NULL, string_list); // initialize callback
+  gint sid = g_signal_connect(notifier, "ignore-snap-event",
+                              (GCallback)test_ignore_event_cb, &signal_counter);
+
+  // run the test
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file); // delete desktop file
+  g_signal_handler_disconnect(notifier, sid);
+
+  g_assert_cmpstr(result, ==, "ignore-snaps");
+  g_assert_cmpint(signal_counter, ==, 1);
+}
+
+void test_update_available_4(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test4_1", "Test app 4_1", icon_path);
+  g_autofree gchar *desktop_file2 =
+      create_desktop_file("test4_2", "Test app 4_2", icon_path);
+
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app4_1", desktop_file1);
+  g_autoptr(GPtrArray) apps2 = add_app(NULL, "test_app4_2", desktop_file2);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap4_1", apps1);
+  g_autoptr(SnapdSnap) snap2 = create_snap("test_snap4_2", apps2);
+  g_autoptr(GListStore) snaps = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snaps, snap1);
+  g_list_store_append(snaps, snap2);
+  sdi_notify_pending_refresh(notifier, G_LIST_MODEL(snaps), NULL);
+
+  gint signal_counter = 0;
+  gchar *string_list[] = {"test_snap4_1", "test_snap4_2"};
+  test_ignore_event_cb(NULL, NULL, string_list); // initialize callback
+
+  gint sid = g_signal_connect(notifier, "ignore-snap-event",
+                              (GCallback)test_ignore_event_cb, &signal_counter);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  unlink(desktop_file2); // delete desktop file
+  g_signal_handler_disconnect(notifier, sid);
+  g_assert_cmpstr(result, ==, "ignore-snaps");
+  g_assert_cmpint(signal_counter, ==, 2);
+}
+
+void test_update_available_5(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test5_1", "Test app 5_1", icon_path);
+  g_autofree gchar *desktop_file2 =
+      create_desktop_file("test5_2", "Test app 5_2", icon_path);
+  g_autofree gchar *desktop_file3 =
+      create_desktop_file("test5_3", "Test app 5_3", icon_path);
+
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app5_1", desktop_file1);
+  g_autoptr(GPtrArray) apps2 = add_app(NULL, "test_app5_2", desktop_file2);
+  g_autoptr(GPtrArray) apps3 = add_app(NULL, "test_app5_3", desktop_file3);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap5_1", apps1);
+  g_autoptr(SnapdSnap) snap2 = create_snap("test_snap5_2", apps2);
+  g_autoptr(SnapdSnap) snap3 = create_snap("test_snap5_3", apps3);
+  g_autoptr(GListStore) snaps = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snaps, snap1);
+  g_list_store_append(snaps, snap2);
+  g_list_store_append(snaps, snap3);
+  sdi_notify_pending_refresh(notifier, G_LIST_MODEL(snaps), NULL);
+
+  gint signal_counter = 0;
+  gchar *string_list[] = {"test_snap5_1", "test_snap5_2", "test_snap5_3"};
+  test_ignore_event_cb(NULL, NULL, string_list); // initialize callback
+
+  gint sid = g_signal_connect(notifier, "ignore-snap-event",
+                              (GCallback)test_ignore_event_cb, &signal_counter);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  unlink(desktop_file2); // delete desktop file
+  unlink(desktop_file3); // delete desktop file
+  g_signal_handler_disconnect(notifier, sid);
+  g_assert_cmpstr(result, ==, "ignore-snaps");
+  g_assert_cmpint(signal_counter, ==, 3);
+}
+
+void test_update_available_6(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test6_1", "Test app 6_1", icon_path);
+  g_autofree gchar *desktop_file2 =
+      create_desktop_file("test6_2", "Test app 6_2", icon_path);
+  g_autofree gchar *desktop_file3 =
+      create_desktop_file("test6_3", "Test app 6_3", icon_path);
+  g_autofree gchar *desktop_file4 =
+      create_desktop_file("test6_4", "Test app 6_4", icon_path);
+
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app6_1", desktop_file1);
+  g_autoptr(GPtrArray) apps2 = add_app(NULL, "test_app6_2", desktop_file2);
+  g_autoptr(GPtrArray) apps3 = add_app(NULL, "test_app6_3", desktop_file3);
+  g_autoptr(GPtrArray) apps4 = add_app(NULL, "test_app6_4", desktop_file4);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap6_1", apps1);
+  g_autoptr(SnapdSnap) snap2 = create_snap("test_snap6_2", apps2);
+  g_autoptr(SnapdSnap) snap3 = create_snap("test_snap6_3", apps3);
+  g_autoptr(SnapdSnap) snap4 = create_snap("test_snap6_4", apps4);
+  g_autoptr(GListStore) snaps = g_list_store_new(SNAPD_TYPE_SNAP);
+  g_list_store_append(snaps, snap1);
+  g_list_store_append(snaps, snap2);
+  g_list_store_append(snaps, snap3);
+  g_list_store_append(snaps, snap4);
+  sdi_notify_pending_refresh(notifier, G_LIST_MODEL(snaps), NULL);
+
+  gint signal_counter = 0;
+  gchar *string_list[] = {"test_snap6_1", "test_snap6_2", "test_snap6_3",
+                          "test_snap6_4"};
+  test_ignore_event_cb(NULL, NULL, string_list); // initialize callback
+
+  gint sid = g_signal_connect(notifier, "ignore-snap-event",
+                              (GCallback)test_ignore_event_cb, &signal_counter);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  unlink(desktop_file2); // delete desktop file
+  unlink(desktop_file3); // delete desktop file
+  unlink(desktop_file4); // delete desktop file
+  g_signal_handler_disconnect(notifier, sid);
+  g_assert_cmpstr(result, ==, "ignore-snaps");
+  g_assert_cmpint(signal_counter, ==, 4);
+}
+
+void test_update_available_7(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test7", "Test app 7", icon_path);
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app7", desktop_file1);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap7", apps1);
+  sdi_notify_refresh_complete(notifier, snap1, "test_snap7", NULL);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  g_autofree gchar *expected =
+      g_strdup_printf("app-launch-updated %s", desktop_file1);
+  g_assert_cmpstr(result, ==, expected);
+}
+
+void test_update_available_8(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test8", "Test app 8", icon_path);
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app8", desktop_file1);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap8", apps1);
+  sdi_notify_pending_refresh_forced(notifier, snap1, SECONDS_IN_A_DAY * 2, TRUE,
+                                    NULL);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  g_assert_cmpstr(result, ==, "show-updates");
+}
+
+void test_update_available_9(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test9", "Test app 9", icon_path);
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app9", desktop_file1);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap9", apps1);
+  sdi_notify_pending_refresh_forced(notifier, snap1, SECONDS_IN_AN_HOUR * 5,
+                                    FALSE, NULL);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  g_assert_cmpstr(result, ==, "show-updates");
+}
+
+void test_update_available_10(TestData *test) {
+  describe_test(test);
+
+  g_autofree gchar *icon_path = get_data_path("icon1.svg");
+  g_autofree gchar *desktop_file1 =
+      create_desktop_file("test10", "Test app 10", icon_path);
+  g_autoptr(GPtrArray) apps1 = add_app(NULL, "test_app10", desktop_file1);
+  g_autoptr(SnapdSnap) snap1 = create_snap("test_snap10", apps1);
+  sdi_notify_pending_refresh_forced(notifier, snap1, SECONDS_IN_A_MINUTE * 13,
+                                    TRUE, NULL);
+
+  gint signal_counter = 0;
+  gchar *string_list[] = {"test_snap10"};
+  test_ignore_event_cb(NULL, NULL, string_list); // initialize callback
+
+  gint sid = g_signal_connect(notifier, "ignore-snap-event",
+                              (GCallback)test_ignore_event_cb, &signal_counter);
+
+  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  unlink(desktop_file1); // delete desktop file
+  g_signal_handler_disconnect(notifier, sid);
+  g_assert_cmpstr(result, ==, "ignore-snaps");
+  g_assert_cmpint(signal_counter, ==, 1);
+}
+
+/**
+ * Each test must have an entry in test_data
+ */
+
+TestData test_data[] = {
+    {1, "/update_available/test1",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Update available for Test app 1', 'Quit the app to "
+     "update now' will appear, with two buttons: 'Show updates' and 'Don't "
+     "remind me again'.",
+     "Press the button 'Show updates'", NULL, test_update_available_1},
+    {2, "/update_available/test2",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Update available for Test app 2', 'Quit the app to "
+     "update now' will appear, with two buttons: 'Show updates' and 'Don't "
+     "remind me again'.",
+     "Press the notification itself (but not the 'close' button) to launch the "
+     "default action.",
+     NULL, test_update_available_2},
+    {3, "/update_available/test3",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Update available for Test app 3', 'Quit the app to "
+     "update now' will appear, with two buttons: 'Show updates' and 'Don't "
+     "remind me again'.",
+     "Press the 'Don't remind me again' button.", NULL,
+     test_update_available_3},
+    {4, "/update_available/test4",
+     "A notification with the app store icon (an orange bag with an A), and "
+     "the text 'Updates available for 2 apps' 'Test app 4_1 and Test app 4_2 "
+     "will update when you quit them.' will appear, with two buttons: 'Show "
+     "updates' and 'Don't remind me again'.",
+     "Press the 'Don't remind me again' button.", NULL,
+     test_update_available_4},
+    {5, "/update_available/test5",
+     "A notification with the app store icon (an orange bag with an A), and "
+     "the text 'Updates available for 3 apps' 'Test app 5_1, Test app 5_2 and "
+     "Test app 5_3 "
+     "will update when you quit them.' will appear, with two buttons: 'Show "
+     "updates' and 'Don't remind me again'.",
+     "Press the 'Don't remind me again' button.", NULL,
+     test_update_available_5},
+    {6, "/update_available/test6",
+     "A notification with the app store icon (an orange bag with an A), and "
+     "the text 'Updates available for 4 apps' 'Quit the apps to update them "
+     "now.' will appear, with two buttons: 'Show "
+     "updates' and 'Don't remind me again'.",
+     "Press the 'Don't remind me again' button.", NULL,
+     test_update_available_6},
+    {7, "/update_done/test7",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Test app 7 was updated', 'You can reopen it now.' "
+     "will appear.",
+     "Click on the notification.", NULL, test_update_available_7},
+    {8, "/update_forced/test8",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Test app 8 will quit and update in 2 days', 'Save "
+     "your progress and quit now to prevent data loss' will appear, with two "
+     "buttons: 'Show updates' and 'Don't "
+     "remind me again'.",
+     "Click on the notification.", NULL, test_update_available_8},
+    {9, "/update_forced/test9",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Test app 9 will quit and update in 2 days', 'Save "
+     "your progress and quit now to prevent data loss' will appear, with one "
+     "button: 'Show updates'",
+     "Click on the 'Show updates' button.", NULL, test_update_available_9},
+    {10, "/update_forced/test10",
+     "A notification with an icon that consists on a pale pink circle with a T "
+     "inside, and the text 'Test app 10 will quit and update in 2 days', 'Save "
+     "your progress and quit now to prevent data loss' will appear, with two "
+     "buttons: 'Show updates' and 'Don't "
+     "remind me again'.",
+     "Click on the 'Don't remind me again' button.", NULL,
+     test_update_available_10},
+    {-1, NULL, NULL, NULL, NULL, NULL}};
+
+/**
+ * GApplication callbacks
+ */
+
+static void do_startup(GObject *object, gpointer data) {
+  notifier = sdi_notify_new(G_APPLICATION(object));
+}
+
+static void do_activate(GObject *object, gpointer data) {
+  // because, by default, there are no windows, so the application would quit
+  g_application_hold(G_APPLICATION(object));
+
+  // add tests
+  for (TestData *test = test_data; test->test_number != -1; test++) {
+    g_test_add_data_func(test->title, test, (GTestDataFunc)test->test_function);
+  }
+  g_test_run();
+  g_application_release(G_APPLICATION(object));
+}
+
+int main(int argc, char **argv) {
+  g_test_init(&argc, &argv, NULL);
+  // here we will create any temporary files
+  tmpdirpath = g_dir_make_tmp(NULL, NULL);
+
+  g_autoptr(GApplication) app = g_application_new("io.snapcraft.SdiNotifyTest",
+                                                  G_APPLICATION_DEFAULT_FLAGS);
+  g_signal_connect(app, "startup", (GCallback)do_startup, NULL);
+  g_signal_connect(app, "activate", (GCallback)do_activate, NULL);
+  g_application_run(app, argc, argv);
+  g_free(tmpdirpath);
+}

--- a/tests/test-sdi-notify.c
+++ b/tests/test-sdi-notify.c
@@ -39,8 +39,8 @@ gchar *tmpdirpath = NULL;
  */
 
 static void describe_test(TestData *test) {
-  g_assert(test != NULL);
-  g_assert(test->test_number != -1);
+  g_assert_nonnull(test);
+  g_assert_cmpint(test->test_number, !=, -1);
   // g_print("\e[1;1H\e[2J"); // clear screen
   g_print("\n\n\n\n");
   g_print("Test number %d\n", test->test_number);
@@ -63,7 +63,7 @@ static gchar *create_desktop_file(gchar *name, gchar *visible_name,
   g_autofree gchar *filename = g_strdup_printf("%s.desktop", name);
   gchar *desktop_path = g_build_path("/", tmpdirpath, filename, NULL);
   FILE *f = fopen(desktop_path, "w");
-  g_assert(f != NULL);
+  g_assert_nonnull(f);
   fprintf(
       f,
       "[Desktop Entry]\nVersion=1.0\nType=Application\nExec=/usr/bin/xmessage "

--- a/tests/test-sdi-notify.c
+++ b/tests/test-sdi-notify.c
@@ -1,6 +1,26 @@
 #include "../src/sdi-forced-refresh-time-constants.h"
 #include "../src/sdi-notify.h"
 #include "gtk/gtk.h"
+
+/**
+ * Unitary tests
+ *
+ * Since these tests work with the notifications system, they can't be
+ * easily integrated into CI because they require to be able to show
+ * true notifications. Anyway, this code shouldn't need to be touched
+ * too much, so having to run these tests manually should not be a
+ * problem.
+ *
+ * To run these tests, just run this test program from a command line,
+ * check that each notification has the text specified in the test
+ * description (shown in the terminal),and click where the test description
+ * tells you to click.
+ *
+ * It is strongly recommended to run this test with Valgrind with the
+ * option --leak-check=full, to also detect memory leaks and wrong
+ * memory accesses.
+ */
+
 SdiNotify *notifier = NULL;
 
 typedef struct _testData {


### PR DESCRIPTION
This PR does some refactoring on the `sdi-notify` object to allow to be connected through signals to the `sdi-refresh-monitor` object (mainly replace the GSList with the list of applications that have available refreshes, with a GListModel, a GObject with the same functionality, which is easier to send through signals). It also moves the little function that checks if a refresh is or not forced, from the `notify` object into the `monitor` object, thus ensuring that the `notify` object is just as "dumb" as possible about the refresh process.

This change not only decouples more the code between the refresh monitor and the notifications object; it also allows to add ten unitary tests for the notifications code (although they can't be run automatically because they require to connect to the desktop notifications daemon; maybe with OpenQA, or using an emulation of the notification daemon...) to ensure that the `sdi-notify` object works as expected.