### PR TITLE
Revert "Update to Core24 (#108)"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,5 +1,5 @@
 name: snapd-desktop-integration
-base: core24
+base: core22
 adopt-info: snapd-desktop-integration
 summary: Desktop Integration for snapd
 description: |


### PR DESCRIPTION
This reverts commit 0bd45e0db93bd9f5463df5755761ee61efd03d3d.

We decided to keep core22 snaps for Oracular