### PR TITLE
Remove empty lines at the beginning of blocks

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+KeepEmptyLinesAtTheStartOfBlocks: false

--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -281,7 +281,6 @@ static void show_pending_update_notification(SdiNotify *self,
                                              const gchar *body, GIcon *icon,
                                              GSList *snaps,
                                              gboolean allow_to_ignore) {
-
   g_autoptr(GNotification) notification = g_notification_new(title);
   g_notification_set_body(notification, body);
   if (icon != NULL) {

--- a/src/sdi-refresh-dialog.c
+++ b/src/sdi-refresh-dialog.c
@@ -208,7 +208,6 @@ static void set_icon_image(SdiRefreshDialog *self, GdkPixbuf *image) {
 
 void sdi_refresh_dialog_set_icon_from_data(SdiRefreshDialog *self,
                                            GBytes *data) {
-
   g_autoptr(GInputStream) istream = NULL;
   g_autoptr(GdkPixbuf) image = NULL;
   istream = g_memory_input_stream_new_from_bytes(data);

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -208,7 +208,6 @@ static void add_dialog_to_main_window(SdiRefreshMonitor *self,
 
 static void begin_application_refresh(GObject *source, GAsyncResult *res,
                                       gpointer p) {
-
   g_autoptr(SnapRefreshData) data = p;
   g_autoptr(SdiRefreshMonitor) self = g_steal_pointer(&data->self);
   g_autoptr(GError) error = NULL;
@@ -702,7 +701,6 @@ void sdi_refresh_monitor_class_init(SdiRefreshMonitorClass *klass) {
 }
 
 SdiRefreshMonitor *sdi_refresh_monitor_new(GApplication *application) {
-
   g_autoptr(SdiNotify) notify = sdi_notify_new(application);
   SdiRefreshMonitor *self =
       g_object_new(SDI_TYPE_REFRESH_MONITOR, "notify", notify, NULL);
@@ -717,7 +715,6 @@ SdiRefreshMonitor *sdi_refresh_monitor_new(GApplication *application) {
 }
 
 gboolean sdi_refresh_monitor_start(SdiRefreshMonitor *self, GError **error) {
-
   g_return_val_if_fail(SDI_IS_REFRESH_MONITOR(self), FALSE);
 
   snapd_notices_monitor_start(self->snapd_monitor, NULL);


### PR DESCRIPTION
Adds a clang-format option to remove empty lines at the beginning of blocks.