### PR TITLE
Fix NULL text in progress bar

### DIFF
--- a/src/sdi-refresh-dialog.c
+++ b/src/sdi-refresh-dialog.c
@@ -155,7 +155,7 @@ void sdi_refresh_dialog_set_percentage_progress(SdiRefreshDialog *self,
   gtk_progress_bar_set_fraction(self->progress_bar, percent);
   gtk_progress_bar_set_show_text(self->progress_bar, TRUE);
   if ((bar_text != NULL) && (bar_text[0] == 0)) {
-    gtk_progress_bar_set_text(self->progress_bar, NULL);
+    gtk_progress_bar_set_text(self->progress_bar, "");
   } else {
     gtk_progress_bar_set_text(self->progress_bar, bar_text);
   }

--- a/src/sdi-refresh-dialog.c
+++ b/src/sdi-refresh-dialog.c
@@ -154,7 +154,7 @@ void sdi_refresh_dialog_set_percentage_progress(SdiRefreshDialog *self,
   self->message = g_strdup(bar_text);
   gtk_progress_bar_set_fraction(self->progress_bar, percent);
   gtk_progress_bar_set_show_text(self->progress_bar, TRUE);
-  if ((bar_text != NULL) && (bar_text[0] == 0)) {
+  if (bar_text == NULL) {
     gtk_progress_bar_set_text(self->progress_bar, "");
   } else {
     gtk_progress_bar_set_text(self->progress_bar, bar_text);


### PR DESCRIPTION
When no text is specified for a progress bar, NULL is passed to gtk_progress_bar_set_text(). Unfortunately, this shows the text (NULL) instead of leaving it blank.

This patch fixes this.