### PR TITLE
Use weston to test theme changes in CI

### DIFF
--- a/.github/workflows/unitary-test.yaml
+++ b/.github/workflows/unitary-test.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt update
-          sudo DEBIAN_FRONTEND=noninteractive apt install -y meson ninja-build jq libgtk-4-dev libnotify-dev libsoup-3.0-dev libjson-glib-dev libpolkit-gobject-1-dev
+          sudo DEBIAN_FRONTEND=noninteractive apt install -y meson ninja-build jq libgtk-4-dev libnotify-dev libsoup-3.0-dev libjson-glib-dev libpolkit-gobject-1-dev weston
       - name: Build snapd-glib
         run: |
           git clone https://github.com/snapcore/snapd-glib.git
@@ -27,5 +27,9 @@ jobs:
           meson setup _build
           ninja -C _build
       - name: Test theme change
+        run: |
+          # can't use XVFB because gtk_settings uses Xsettings by default, but we need to use keyfile backend
+          weston --config=$PWD/tests/weston-test-theme-change.ini --socket=wl-test-env
+      - name: Test notices monitor
         run: |
           ./_build/tests/test-sdi-notices-monitor

--- a/tests/test-snapd-desktop-integration.c
+++ b/tests/test-snapd-desktop-integration.c
@@ -417,7 +417,9 @@ int main(int argc, char **argv) {
 
   g_main_loop_run(loop);
 
+  g_print("Tests passed\n");
   if (dbus_subprocess != NULL) {
+    g_print("Killing subprocesses\n");
     g_subprocess_force_exit(dbus_subprocess);
   }
 

--- a/tests/weston-test-theme-change.ini
+++ b/tests/weston-test-theme-change.ini
@@ -1,0 +1,5 @@
+[core]
+backend=headless
+[autolaunch]
+path=./_build/tests/test-snapd-desktop-integration
+watch=true


### PR DESCRIPTION
This PR runs the `test-snapd-desktop-integration` (theme-change test) in the CI.