### PR TITLE
Add "dead code" tags to fix cppcheck errors

### DIFF
--- a/tests/test-sdi-notices-monitor.c
+++ b/tests/test-sdi-notices-monitor.c
@@ -8,6 +8,7 @@ typedef struct {
   int counter;
 } AsyncData;
 
+// TICS -DEADCODE: it's a test
 static AsyncData *async_data_new(GMainLoop *loop, MockSnapd *snapd) {
   AsyncData *data = g_slice_new0(AsyncData);
   data->loop = g_main_loop_ref(loop);
@@ -15,6 +16,7 @@ static AsyncData *async_data_new(GMainLoop *loop, MockSnapd *snapd) {
   return data;
 }
 
+// TICS -DEADCODE: it's a test
 static void async_data_free(AsyncData *data) {
   g_main_loop_unref(data->loop);
   g_object_unref(data->snapd);
@@ -23,6 +25,7 @@ static void async_data_free(AsyncData *data) {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(AsyncData, async_data_free)
 
+// TICS -DEADCODE: it's a test
 static MockNotice *create_notice(MockSnapd *snapd, const gchar *kind) {
   MockNotice *notice = mock_snapd_add_notice(snapd, "1", "8473", kind);
   g_autoptr(GTimeZone) timezone = g_time_zone_new_utc();
@@ -39,6 +42,7 @@ static MockNotice *create_notice(MockSnapd *snapd, const gchar *kind) {
   return notice;
 }
 
+// TICS -DEADCODE: it's a test
 static void test_notices_events_are_received_cb(SdiSnapdMonitor *self,
                                                 SnapdNotice *notice,
                                                 gboolean first_set,
@@ -74,6 +78,7 @@ static void test_notices_events_are_received_cb(SdiSnapdMonitor *self,
   }
 }
 
+// TICS -DEADCODE: it's a test
 static void test_notices_events_are_received(void) {
   g_autoptr(GMainLoop) loop = g_main_loop_new(NULL, FALSE);
 
@@ -97,6 +102,7 @@ static void test_notices_events_are_received(void) {
   g_object_unref(data->snapd); // it has two references
 }
 
+// TICS -DEADCODE: it's a test
 int main(int argc, char **argv) {
   g_test_init(&argc, &argv, NULL);
   g_test_add_func("/sdi-snapd-monitor/receive-notices",

--- a/tests/test-sdi-notify.c
+++ b/tests/test-sdi-notify.c
@@ -37,7 +37,7 @@ gchar *tmpdirpath = NULL;
 /**
  * Several help functions
  */
-
+// TICS -DEADCODE: it's a test
 static void describe_test(TestData *test) {
   g_assert_nonnull(test);
   g_assert_cmpint(test->test_number, !=, -1);
@@ -52,12 +52,14 @@ static void describe_test(TestData *test) {
   g_print("Waiting for actions\n");
 }
 
+// TICS -DEADCODE: it's a test
 static gchar *get_data_path(gchar *resource_name) {
   g_autofree gchar *path =
       g_test_build_filename(G_TEST_BUILT, "data", resource_name, NULL);
   return g_canonicalize_filename(path, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 static gchar *create_desktop_file(gchar *name, gchar *visible_name,
                                   gchar *icon) {
   g_autofree gchar *filename = g_strdup_printf("%s.desktop", name);
@@ -79,11 +81,13 @@ static gchar *create_desktop_file(gchar *name, gchar *visible_name,
   return desktop_path;
 }
 
+// TICS -DEADCODE: it's a test
 static SnapdApp *create_app(gchar *name, gchar *desktop_file) {
   return g_object_new(SNAPD_TYPE_APP, "name", name, "desktop-file",
                       desktop_file, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 static GPtrArray *add_app(GPtrArray *array, gchar *name, gchar *desktop_file) {
   if (array == NULL) {
     array = g_ptr_array_new_full(1, g_object_unref);
@@ -92,10 +96,12 @@ static GPtrArray *add_app(GPtrArray *array, gchar *name, gchar *desktop_file) {
   return array;
 }
 
+// TICS -DEADCODE: it's a test
 static SnapdSnap *create_snap(gchar *snap_name, GPtrArray *apps) {
   return g_object_new(SNAPD_TYPE_SNAP, "apps", apps, "name", snap_name, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 static gchar *wait_for_notification_close_cb(GObject *self, gchar *param,
                                              gpointer data) {
   static GMainLoop *loop = NULL;
@@ -117,6 +123,7 @@ static gchar *wait_for_notification_close_cb(GObject *self, gchar *param,
   return NULL;
 }
 
+// TICS -DEADCODE: it's a test
 static gchar *wait_for_notification_close() {
   return wait_for_notification_close_cb(NULL, NULL, NULL);
 }
@@ -125,6 +132,7 @@ static gchar *wait_for_notification_close() {
  * Test functions
  */
 
+// TICS -DEADCODE: it's a test
 void test_update_available_1(TestData *test) {
   describe_test(test);
 
@@ -143,6 +151,7 @@ void test_update_available_1(TestData *test) {
   g_assert_cmpstr(result, ==, "show-updates");
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_2(TestData *test) {
   describe_test(test);
 
@@ -161,6 +170,7 @@ void test_update_available_2(TestData *test) {
   g_assert_cmpstr(result, ==, "show-updates");
 }
 
+// TICS -DEADCODE: it's a test
 static void test_ignore_event_cb(GObject *self, gchar *value, gpointer data) {
   static gint counter = 0;
   static gchar **string_list;
@@ -175,6 +185,7 @@ static void test_ignore_event_cb(GObject *self, gchar *value, gpointer data) {
   *external_counter = counter;
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_3(TestData *test) {
   describe_test(test);
 
@@ -203,6 +214,7 @@ void test_update_available_3(TestData *test) {
   g_assert_cmpint(signal_counter, ==, 1);
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_4(TestData *test) {
   describe_test(test);
 
@@ -236,6 +248,7 @@ void test_update_available_4(TestData *test) {
   g_assert_cmpint(signal_counter, ==, 2);
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_5(TestData *test) {
   describe_test(test);
 
@@ -275,6 +288,7 @@ void test_update_available_5(TestData *test) {
   g_assert_cmpint(signal_counter, ==, 3);
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_6(TestData *test) {
   describe_test(test);
 
@@ -321,6 +335,7 @@ void test_update_available_6(TestData *test) {
   g_assert_cmpint(signal_counter, ==, 4);
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_7(TestData *test) {
   describe_test(test);
 
@@ -338,6 +353,7 @@ void test_update_available_7(TestData *test) {
   g_assert_cmpstr(result, ==, expected);
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_8(TestData *test) {
   describe_test(test);
 
@@ -354,6 +370,7 @@ void test_update_available_8(TestData *test) {
   g_assert_cmpstr(result, ==, "show-updates");
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_9(TestData *test) {
   describe_test(test);
 
@@ -370,6 +387,7 @@ void test_update_available_9(TestData *test) {
   g_assert_cmpstr(result, ==, "show-updates");
 }
 
+// TICS -DEADCODE: it's a test
 void test_update_available_10(TestData *test) {
   describe_test(test);
 
@@ -475,10 +493,12 @@ TestData test_data[] = {
  * GApplication callbacks
  */
 
+// TICS -DEADCODE: it's a test
 static void do_startup(GObject *object, gpointer data) {
   notifier = sdi_notify_new(G_APPLICATION(object));
 }
 
+// TICS -DEADCODE: it's a test
 static void do_activate(GObject *object, gpointer data) {
   // because, by default, there are no windows, so the application would quit
   g_application_hold(G_APPLICATION(object));
@@ -491,6 +511,7 @@ static void do_activate(GObject *object, gpointer data) {
   g_application_release(G_APPLICATION(object));
 }
 
+// TICS -DEADCODE: it's a test
 int main(int argc, char **argv) {
   g_test_init(&argc, &argv, NULL);
   // here we will create any temporary files

--- a/tests/test-sdi-progress-dock.c
+++ b/tests/test-sdi-progress-dock.c
@@ -13,6 +13,7 @@ enum CHANGES_LIST {
   CHANGES_UPDATING = 4
 } current_changes = 0;
 
+// TICS -DEADCODE: it's a test
 static void set_progress_bar(gchar *desktop_file, guint done_tasks,
                              guint total_tasks, gboolean all_done) {
   current_changes = 0;
@@ -24,11 +25,13 @@ static void set_progress_bar(gchar *desktop_file, guint done_tasks,
                                     all_done);
 }
 
+// TICS -DEADCODE: it's a test
 static void timeoutCB(guint *timeout_id) {
   g_assert_cmpint(*timeout_id, !=, 0);
   *timeout_id = 0;
 }
 
+// TICS -DEADCODE: it's a test
 static void wait_for_events(guint timeout, guint changes) {
   GMainContext *context = g_main_context_default();
   guint timeout_id =
@@ -41,6 +44,7 @@ static void wait_for_events(guint timeout, guint changes) {
 
 // these are the actual tests
 
+// TICS -DEADCODE: it's a test
 static void test_progress_bar() {
   g_assert_false(updating_value);
   g_assert_false(progress_visible_value);
@@ -68,6 +72,7 @@ static void test_progress_bar() {
   g_assert_cmpfloat_with_epsilon(progress_value, 10 / 10.0, DBL_EPSILON);
 }
 
+// TICS -DEADCODE: it's a test
 static void test_updating() {
   g_assert_true(updating_value);
   g_assert_true(progress_visible_value);
@@ -84,6 +89,7 @@ static void test_updating() {
  * GApplication callbacks
  */
 
+// TICS -DEADCODE: it's a test
 static void dockCB(GDBusConnection *connection, const gchar *sender_name,
                    const gchar *object_path, const gchar *interface_name,
                    const gchar *signal_name, GVariant *parameters,
@@ -126,6 +132,7 @@ static void dockCB(GDBusConnection *connection, const gchar *sender_name,
   }
 }
 
+// TICS -DEADCODE: it's a test
 static void do_startup(GApplication *application, gpointer data) {
   progress_dock = sdi_progress_dock_new(application);
   g_autoptr(GDBusConnection) dbus_conn =
@@ -135,6 +142,7 @@ static void do_startup(GApplication *application, gpointer data) {
       NULL, G_DBUS_SIGNAL_FLAGS_NONE, (GDBusSignalCallback)dockCB, NULL, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 static void do_activate(GApplication *app, gpointer data) {
   g_test_add_func("/dock/progress-bar", test_progress_bar);
   g_test_add_func("/dock/updating", test_updating);

--- a/tests/test-sdi-progress-window.c
+++ b/tests/test-sdi-progress-window.c
@@ -26,12 +26,14 @@ gchar *app_list[] = {"kicad_kicad.desktop", "simple-scan_simple-scan.desktop",
  * Several help functions
  */
 
+// TICS -DEADCODE: it's a test
 static void buttons_callback(GtkButton *button, gchar *answer) {
   g_assert_cmpstr(answer, ==, "yes");
   g_assert_false(clicked_on_wait);
   clicked_on_wait = TRUE;
 }
 
+// TICS -DEADCODE: it's a test
 static GtkApplicationWindow *create_window(GApplication *app) {
   GtkApplicationWindow *app_window =
       GTK_APPLICATION_WINDOW(gtk_application_window_new(GTK_APPLICATION(app)));
@@ -53,6 +55,7 @@ static GtkApplicationWindow *create_window(GApplication *app) {
   return app_window;
 }
 
+// TICS -DEADCODE: it's a test
 static void describe_test(TestData *test) {
   g_assert_nonnull(test);
   g_assert(test->test_number);
@@ -62,6 +65,7 @@ static void describe_test(TestData *test) {
   gtk_label_set_label(window_text, text);
 }
 
+// TICS -DEADCODE: it's a test
 static gboolean set_progress_bar(gchar *snap_name) {
   static guint done_tasks = 0;
   guint total_tasks = 10;
@@ -77,6 +81,7 @@ static gboolean set_progress_bar(gchar *snap_name) {
   return G_SOURCE_CONTINUE;
 }
 
+// TICS -DEADCODE: it's a test
 static void wait_for_click() {
   GMainContext *context = g_main_context_default();
   clicked_on_wait = FALSE;
@@ -85,17 +90,20 @@ static void wait_for_click() {
   } while (!clicked_on_wait);
 }
 
+// TICS -DEADCODE: it's a test
 static void enable_buttons(gpointer data) {
   gtk_widget_set_sensitive(GTK_WIDGET(yes_button), TRUE);
   gtk_widget_set_sensitive(GTK_WIDGET(no_button), TRUE);
 }
 
+// TICS -DEADCODE: it's a test
 static void disable_buttons_for_seconds(gint seconds) {
   gtk_widget_set_sensitive(GTK_WIDGET(yes_button), FALSE);
   gtk_widget_set_sensitive(GTK_WIDGET(no_button), FALSE);
   g_timeout_add_once(seconds * 1000, enable_buttons, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 static void show_progress_window(gchar *snap_name, gchar *desktop_file) {
   g_autoptr(GDesktopAppInfo) app_info = g_desktop_app_info_new(desktop_file);
   g_assert_nonnull(app_info);
@@ -106,6 +114,7 @@ static void show_progress_window(gchar *snap_name, gchar *desktop_file) {
       (gchar *)g_app_info_get_display_name(G_APP_INFO(app_info)), icon);
 }
 
+// TICS -DEADCODE: it's a test
 static int count_progress_childs() {
   GtkWindow *window =
       GTK_WINDOW(sdi_progress_window_get_window(progress_window));
@@ -123,6 +132,7 @@ static int count_progress_childs() {
   return counter;
 }
 
+// TICS -DEADCODE: it's a test
 static int count_hash_childs() {
   GHashTable *table = sdi_progress_window_get_dialogs(progress_window);
   g_assert_nonnull(table);
@@ -131,6 +141,7 @@ static int count_hash_childs() {
 
 // these are the actual tests
 
+// TICS -DEADCODE: it's a test
 static void test_progress_bar(TestData *test) {
   describe_test(test);
   show_progress_window("A-SNAP", *app_list);
@@ -142,6 +153,7 @@ static void test_progress_bar(TestData *test) {
   g_source_remove(timeout_id);
 }
 
+// TICS -DEADCODE: it's a test
 static void test_pulse_bar(TestData *test) {
   describe_test(test);
   disable_buttons_for_seconds(6);
@@ -150,6 +162,7 @@ static void test_pulse_bar(TestData *test) {
   wait_for_click();
 }
 
+// TICS -DEADCODE: it's a test
 static void test_close_bar(TestData *test) {
   describe_test(test);
   sdi_progress_window_end_refresh(progress_window, "A-SNAP");
@@ -162,6 +175,7 @@ static void test_close_bar(TestData *test) {
   g_source_remove(timeout_id);
 }
 
+// TICS -DEADCODE: it's a test
 static void test_manual_hide(TestData *test) {
   describe_test(test);
   show_progress_window("B-SNAP", *(app_list + 1));
@@ -174,6 +188,7 @@ static void test_manual_hide(TestData *test) {
   g_source_remove(timeout_id);
 }
 
+// TICS -DEADCODE: it's a test
 static void test_dual_progress_bar1(TestData *test) {
   describe_test(test);
   show_progress_window("C-SNAP", *(app_list));
@@ -183,6 +198,7 @@ static void test_dual_progress_bar1(TestData *test) {
   wait_for_click();
 }
 
+// TICS -DEADCODE: it's a test
 static void test_dual_progress_bar2(TestData *test) {
   describe_test(test);
   show_progress_window("D-SNAP", *(app_list + 1));
@@ -192,6 +208,7 @@ static void test_dual_progress_bar2(TestData *test) {
   wait_for_click();
 }
 
+// TICS -DEADCODE: it's a test
 static void test_dual_progress_bar3(TestData *test) {
   describe_test(test);
   sdi_progress_window_end_refresh(progress_window, "C-SNAP");
@@ -201,6 +218,7 @@ static void test_dual_progress_bar3(TestData *test) {
   g_source_remove(timeout_id1);
 }
 
+// TICS -DEADCODE: it's a test
 static void test_dual_progress_bar4(TestData *test) {
   describe_test(test);
   sdi_progress_window_end_refresh(progress_window, "D-SNAP");
@@ -277,12 +295,14 @@ TestData test_data[] = {
  * GApplication callbacks
  */
 
+// TICS -DEADCODE: it's a test
 static void do_startup(GObject *object, gpointer data) {
   progress_window = sdi_progress_window_new(G_APPLICATION(object));
 
   g_assert_nonnull(app_list);
 }
 
+// TICS -DEADCODE: it's a test
 static void do_activate(GApplication *app, gpointer data) {
   window = create_window(app);
 
@@ -294,11 +314,13 @@ static void do_activate(GApplication *app, gpointer data) {
   g_object_unref(window);
 }
 
+// TICS -DEADCODE: it's a test
 static gchar *get_data_path() {
   g_autofree gchar *path = g_test_build_filename(G_TEST_BUILT, "data", NULL);
   return g_canonicalize_filename(path, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 void set_environment() {
   const gchar *data_dirs = g_getenv("XDG_DATA_DIRS");
   g_autofree gchar *share_path = get_data_path();
@@ -306,6 +328,7 @@ void set_environment() {
   g_setenv("XDG_DATA_DIRS", newvar, TRUE);
 }
 
+// TICS -DEADCODE: it's a test
 int main(int argc, char **argv) {
   g_test_init(&argc, &argv, NULL);
   set_environment();

--- a/tests/test-snapd-desktop-integration.c
+++ b/tests/test-snapd-desktop-integration.c
@@ -42,6 +42,7 @@ enum {
   STATE_NOTIFY_COMPLETE
 } state = STATE_GET_EXISTING_THEME_STATUS;
 
+// TICS -DEADCODE: it's a test
 static gchar *get_json(SoupMessageBody *message_body) {
   g_autoptr(JsonParser) parser = json_parser_new();
   if (!json_parser_load_from_data(parser, message_body->data,
@@ -55,6 +56,7 @@ static gchar *get_json(SoupMessageBody *message_body) {
   return json_generator_to_data(generator, NULL);
 }
 
+// TICS -DEADCODE: it's a test
 static void set_setting(const gchar *schema_name, const gchar *key_name,
                         const gchar *value) {
   g_autofree gchar *filename =
@@ -66,6 +68,7 @@ static void set_setting(const gchar *schema_name, const gchar *key_name,
   g_settings_set_string(settings, key_name, value);
 }
 
+// TICS -DEADCODE: it's a test
 static void send_snapd_response(SoupServerMessage *message, guint status_code,
                                 const gchar *json) {
   soup_server_message_set_status(message, status_code, "");
@@ -77,6 +80,7 @@ static void send_snapd_response(SoupServerMessage *message, guint status_code,
                            SOUP_MEMORY_COPY, json, strlen(json));
 }
 
+// TICS -DEADCODE: it's a test
 static void handle_snapd_themes_request(SoupServerMessage *message) {
   const gchar *query = g_uri_get_query(soup_server_message_get_uri(message));
   switch (state) {
@@ -132,12 +136,14 @@ static void handle_snapd_themes_request(SoupServerMessage *message) {
   }
 }
 
+// TICS -DEADCODE: it's a test
 static void handle_snapd_get_changes_request(SoupServerMessage *message) {
   send_snapd_response(message, 200,
                       "{\"type\":\"sync\",\"status-code\":200,\"status\":"
                       "\"OK\",\"result\":{\"id\":\"1234\",\"ready\":true}}");
 }
 
+// TICS -DEADCODE: it's a test
 static void handle_snapd_request(SoupServer *server, SoupServerMessage *message,
                                  const char *path, GHashTable *query,
                                  gpointer user_data) {
@@ -154,6 +160,7 @@ static void handle_snapd_request(SoupServer *server, SoupServerMessage *message,
   }
 }
 
+// TICS -DEADCODE: it's a test
 static gboolean setup_mock_snapd(GError **error) {
   snapd_socket_path = g_build_filename(temp_dir, "snapd.socket", NULL);
 
@@ -185,6 +192,7 @@ static gboolean setup_mock_snapd(GError **error) {
   return TRUE;
 }
 
+// TICS -DEADCODE: it's a test
 static gboolean setup_session_bus(GError **error) {
   int address_pipe_fds[2];
   if (!g_unix_open_pipe(address_pipe_fds, FD_CLOEXEC, error)) {
@@ -217,6 +225,7 @@ static gboolean setup_session_bus(GError **error) {
   return TRUE;
 }
 
+// TICS -DEADCODE: it's a test
 static gboolean launch_snapd_desktop_integration() {
   g_autoptr(GSubprocessLauncher) launcher =
       g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_NONE);
@@ -242,12 +251,14 @@ static gboolean launch_snapd_desktop_integration() {
   return TRUE;
 }
 
+// TICS -DEADCODE: it's a test
 static void notifications_name_acquired_cb(GDBusConnection *connection,
                                            const gchar *name,
                                            gpointer user_data) {
   g_assert_true(launch_snapd_desktop_integration());
 }
 
+// TICS -DEADCODE: it's a test
 static void handle_notifications_method_call(
     GDBusConnection *connection, const gchar *sender, const gchar *object_path,
     const gchar *interface_name, const gchar *method_name, GVariant *parameters,
@@ -312,6 +323,7 @@ static void handle_notifications_method_call(
   }
 }
 
+// TICS -DEADCODE: it's a test
 static gboolean setup_mock_notifications(GError **error) {
   g_autoptr(GDBusConnection) connection =
       g_dbus_connection_new_for_address_sync(
@@ -384,6 +396,7 @@ static gboolean setup_mock_notifications(GError **error) {
   return TRUE;
 }
 
+// TICS -DEADCODE: it's a test
 int main(int argc, char **argv) {
   loop = g_main_loop_new(NULL, FALSE);
 


### PR DESCRIPTION
This is a test to check if adding this allows to remove the error from Cppcheck that states that there is no coverage for the tests source files.

It just adds the `//TICS -DEADCODE: it's a test` comment before all the functions in the tests code.