### PR TITLE
Fix theme change test

### DIFF
--- a/tests/launch-weston-test-theme-change.sh
+++ b/tests/launch-weston-test-theme-change.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+./_build/tests/test-snapd-desktop-integration
+if [ $? -ne 0 ]; then
+    # sending a kill -9 makes weston return a non-zero value, thus
+    # notifying CI/CD pipeline that this test failed.
+    killall -s 9 weston
+fi

--- a/tests/weston-test-theme-change.ini
+++ b/tests/weston-test-theme-change.ini
@@ -1,5 +1,5 @@
 [core]
 backend=headless
 [autolaunch]
-path=./_build/tests/test-snapd-desktop-integration
+path=./tests/launch-weston-test-theme-change.sh
 watch=true


### PR DESCRIPTION
When launching the theme-change test, it is done through Weston window manager, because it requires it. Unfortunately, if the test fails and returns a non-zero value, Weston doesn't propagate it, so it always returns a zero, thus cheating the CI/CD pipeline and making it believe that the test passed.

This patch fixes this by checking the return value of the test and sending a SIGKILL to Weston if the test failed; this makes Weston to return a non-zero value, thus notifying to the CI/CD pipeline that the test failed.