### PR TITLE
Remove timeout source on destroy

### DIFF
--- a/.github/workflows/tics.yaml
+++ b/.github/workflows/tics.yaml
@@ -43,8 +43,7 @@ jobs:
       - name: Coverage
         run: |
           mkdir -p coverage
-          gcovr _build --cobertura coverage_base/cobertura-tests.xml
-          # merge the prebuilt COBERTURA.XML files with the newly generated
+          gcovr _build --cobertura coverage/cobertura-tests.xml
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4

--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -566,10 +566,15 @@ static void sdi_refresh_monitor_dispose(GObject *object) {
   G_OBJECT_CLASS(sdi_refresh_monitor_parent_class)->dispose(object);
 }
 
+static void remove_source(gpointer data) {
+  g_source_remove(GPOINTER_TO_INT(data));
+}
+
 void sdi_refresh_monitor_init(SdiRefreshMonitor *self) {
   self->snaps =
       g_hash_table_new_full(g_str_hash, g_str_equal, g_free, g_object_unref);
-  self->changes = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+  self->changes =
+      g_hash_table_new_full(g_str_hash, g_str_equal, g_free, remove_source);
   /* the key in this table is the snap name; the value is a SnapProgressTaskData
    * structure.
    */


### PR DESCRIPTION
When a sdi-refresh-monitor object is destroyed, there could remain some g_timeout_once() sources. This patch ensures that they are clean up.