### PR TITLE
Add support for snapd abstract socket

### DIFF
--- a/src/sdi-snapd-client-factory.c
+++ b/src/sdi-snapd-client-factory.c
@@ -42,9 +42,6 @@ SnapdClient *sdi_snapd_client_factory_new_snapd_client(void) {
   if (sdi_snapd_socket_path != NULL) {
     // if a custom path has been set via command-line parameters, use it
     snapd_client_set_socket_path(client, sdi_snapd_socket_path);
-  } else if (g_getenv("SNAP") != NULL) {
-    // snapped applications use a different socket
-    snapd_client_set_socket_path(client, "/run/snapd-snap.socket");
   }
   return client;
 }


### PR DESCRIPTION
Snapd has changed to an abstract socket when used from inside a snap, so a change was required in snapd-glib. Now, the library automagically detects if it is inside a snap and chooses, in that case, the new abstract socket if it exists, or the old, normal socket if the abstract doesn't exist, so the current code to set the socket if we are inside a snap is not only not needed anymore, but it will stop working in the next snapd version, so it must be removed and let snapd-glib to choose the right socket.