### PR TITLE
Add a workaround for Ubuntu Budgie

### DIFF
--- a/src/sdi-notify.c
+++ b/src/sdi-notify.c
@@ -155,8 +155,6 @@ static void ignore_notify_data_free(IgnoreNotifyData *data) {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(IgnoreNotifyData, ignore_notify_data_free)
 
-G_DEFINE_AUTOPTR_CLEANUP_FUNC(NotifyNotification, g_object_unref)
-
 typedef struct {
   SdiNotify *self;
   gchar *desktop;

--- a/tests/test-snapd-desktop-integration.c
+++ b/tests/test-snapd-desktop-integration.c
@@ -304,6 +304,7 @@ static void handle_notifications_method_call(
       g_assert_cmpstr(actions[3], ==, "No");
       g_assert_cmpstr(actions[4], ==, "default");
       g_assert_cmpstr(actions[5], ==, "default");
+      g_assert_cmpint(actions_to_send, !=, 0);
 
       if (actions_to_send & ACTION_SEND_YES) {
         g_print("Sending action YES\n");
@@ -433,6 +434,13 @@ void timeout_no_install(GMainLoop *loop) {
   g_main_loop_quit(loop);
 }
 
+static void set_test_settings() {
+  set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
+  set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
+  set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");
+  set_setting("org.gnome.desktop.sound", "theme-name", "SoundTheme1");
+}
+
 int main(int argc, char **argv) {
   loop = g_main_loop_new(NULL, FALSE);
 
@@ -444,10 +452,7 @@ int main(int argc, char **argv) {
   }
 
   exit_code = SNAPD_EXIT_FAILURE;
-  set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
-  set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
-  set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");
-  set_setting("org.gnome.desktop.sound", "theme-name", "SoundTheme1");
+  set_test_settings();
   actions_to_send = ACTION_SEND_YES | ACTION_SEND_CLOSE;
 
   if (!setup_mock_snapd(&error)) {
@@ -475,10 +480,7 @@ int main(int argc, char **argv) {
   // doesn't break the system.
   exit_code = SNAPD_EXIT_FAILURE;
   state = STATE_GET_EXISTING_THEME_STATUS;
-  set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
-  set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
-  set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");
-  set_setting("org.gnome.desktop.sound", "theme-name", "SoundTheme1");
+  set_test_settings();
   actions_to_send = ACTION_SEND_YES | ACTION_SEND_DEFAULT | ACTION_SEND_CLOSE;
 
   g_main_loop_run(loop);
@@ -489,10 +491,7 @@ int main(int argc, char **argv) {
   // Test that answering NO won't update the themes
   exit_code = SNAPD_EXIT_FAILURE;
   state = STATE_GET_EXISTING_THEME_STATUS;
-  set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
-  set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
-  set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");
-  set_setting("org.gnome.desktop.sound", "theme-name", "SoundTheme1");
+  set_test_settings();
   actions_to_send = ACTION_SEND_NO | ACTION_SEND_CLOSE;
   g_timeout_add_once(4000, (GSourceOnceFunc)timeout_no_install, loop);
 
@@ -504,10 +503,7 @@ int main(int argc, char **argv) {
   // Test that clicking on the notification does install the theme
   exit_code = SNAPD_EXIT_FAILURE;
   state = STATE_GET_EXISTING_THEME_STATUS;
-  set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
-  set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
-  set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");
-  set_setting("org.gnome.desktop.sound", "theme-name", "SoundTheme1");
+  set_test_settings();
   actions_to_send = ACTION_SEND_DEFAULT | ACTION_SEND_CLOSE;
 
   g_main_loop_run(loop);
@@ -519,10 +515,7 @@ int main(int argc, char **argv) {
   // and continues to respond to new changes.
   exit_code = SNAPD_EXIT_FAILURE;
   state = STATE_GET_EXISTING_THEME_STATUS;
-  set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
-  set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
-  set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");
-  set_setting("org.gnome.desktop.sound", "theme-name", "SoundTheme1");
+  set_test_settings();
   actions_to_send = ACTION_SEND_YES | ACTION_SEND_CLOSE;
 
   g_main_loop_run(loop);


### PR DESCRIPTION
Ubuntu Budgie has a bug in its notifications system: when the user clicks on an action (for example, "Yes" for installing new themes from the Snap Store), it sends the button action (thus, "yes" action), but after that also sends the default action. Instead, both Gnome and KDE only sends the button action.

This results in odd behavior in this system: since the default action does the same than the "yes" action, if the user presses "Yes", two install processes will run concurrently, conflicting between them and resulting in an installation error shown (due to one of the processes being unable to install the themes), while, at the same time, the themes are correctly installed (by the second process).

Also, if the user presses "No", the "no" action is just ignored and nothing is done; but the next "default" action is honored and the themes are installed; exactly the opposite of what the user wanted.

This workaround ensures that only one action is honored for each notification, and any extra action is ignored until the install notification is closed and a new notification is shown.

Fix https://github.com/canonical/snapd-desktop-integration/issues/52