### PR TITLE
Update ubuntu version in test

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The ubuntu 20.04 actions runner is being deprecated, so we must update it to a more recent one.

https://github.com/actions/runner-images/issues/11101