### PR TITLE
Fix test build in 25.10

### DIFF
--- a/src/sdi-refresh-monitor.c
+++ b/src/sdi-refresh-monitor.c
@@ -630,7 +630,7 @@ void sdi_refresh_monitor_class_init(SdiRefreshMonitorClass *klass) {
                NULL, NULL, NULL, G_TYPE_NONE, 1, G_TYPE_STRING);
 }
 
-SdiRefreshMonitor *sdi_refresh_monitor_new() {
+SdiRefreshMonitor *sdi_refresh_monitor_new(void) {
   SdiRefreshMonitor *self = g_object_new(SDI_TYPE_REFRESH_MONITOR, NULL);
   return self;
 }

--- a/src/sdi-refresh-monitor.h
+++ b/src/sdi-refresh-monitor.h
@@ -33,7 +33,7 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(SdiRefreshMonitor, sdi_refresh_monitor, SDI,
                      REFRESH_MONITOR, GObject)
 
-SdiRefreshMonitor *sdi_refresh_monitor_new();
+SdiRefreshMonitor *sdi_refresh_monitor_new(void);
 
 void sdi_refresh_monitor_ignore_snap(SdiRefreshMonitor *self,
                                      const gchar *snap_name);

--- a/src/sdi-snapd-monitor.c
+++ b/src/sdi-snapd-monitor.c
@@ -103,7 +103,7 @@ static void sdi_snapd_monitor_class_init(SdiSnapdMonitorClass *klass) {
                G_TYPE_BOOLEAN);
 }
 
-SdiSnapdMonitor *sdi_snapd_monitor_new() {
+SdiSnapdMonitor *sdi_snapd_monitor_new(void) {
   return g_object_new(SDI_TYPE_SNAPD_MONITOR, NULL);
 }
 

--- a/src/sdi-snapd-monitor.h
+++ b/src/sdi-snapd-monitor.h
@@ -27,7 +27,7 @@ G_BEGIN_DECLS
 G_DECLARE_FINAL_TYPE(SdiSnapdMonitor, sdi_snapd_monitor, SDI, SNAPD_MONITOR,
                      GObject)
 
-SdiSnapdMonitor *sdi_snapd_monitor_new();
+SdiSnapdMonitor *sdi_snapd_monitor_new(void);
 
 bool sdi_snapd_monitor_start(SdiSnapdMonitor *self);
 

--- a/tests/mock-fdo-notifications.c
+++ b/tests/mock-fdo-notifications.c
@@ -374,7 +374,7 @@ mock_fdo_notifications_class_init(MockFdoNotificationsClass *klass) {
   G_OBJECT_CLASS(klass)->dispose = mock_fdo_notifications_dispose;
 }
 
-MockFdoNotifications *mock_fdo_notifications_new() {
+MockFdoNotifications *mock_fdo_notifications_new(void) {
   return g_object_new(MOCK_FDO_TYPE_NOTIFICATIONS, NULL);
 }
 

--- a/tests/mock-fdo-notifications.h
+++ b/tests/mock-fdo-notifications.h
@@ -40,7 +40,7 @@ typedef struct {
 G_DECLARE_FINAL_TYPE(MockFdoNotifications, mock_fdo_notifications, MOCK_FDO,
                      NOTIFICATIONS, GObject)
 
-MockFdoNotifications *mock_fdo_notifications_new();
+MockFdoNotifications *mock_fdo_notifications_new(void);
 
 gboolean mock_fdo_notifications_setup_session_bus(GError **error);
 

--- a/tests/test-refresh-monitor.c
+++ b/tests/test-refresh-monitor.c
@@ -79,7 +79,7 @@ static void free_received_signal_data(ReceivedSignalData *data) {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(ReceivedSignalData, free_received_signal_data);
 
-static void clear_received_signals() {
+static void clear_received_signals(void) {
   if (received_signals == NULL) {
     return;
   }
@@ -203,7 +203,7 @@ static ReceivedSignalData *wait_for_signal(ReceivedSignal desired_signal,
   return data;
 }
 
-static void reset_mock_snapd() {
+static void reset_mock_snapd(void) {
   g_clear_object(&snapd_monitor);
   g_clear_object(&snapd);
   g_clear_object(&refresh_monitor);
@@ -226,7 +226,7 @@ static void reset_mock_snapd() {
 
   g_assert_true(snapd_notices_monitor_start(snapd_monitor, &error));
 
-  refresh_monitor = sdi_refresh_monitor_new(NULL);
+  refresh_monitor = sdi_refresh_monitor_new();
 
   g_signal_connect(refresh_monitor, "notify-pending-refresh",
                    (GCallback)notify_pending_refresh_cb, NULL);

--- a/tests/test-sdi-notify.c
+++ b/tests/test-sdi-notify.c
@@ -107,7 +107,7 @@ static gchar *wait_for_notification_close_cb(GObject *self, gchar *param,
   return NULL;
 }
 
-static gchar *wait_for_notification_close() {
+static gchar *wait_for_notification_close(void) {
   return wait_for_notification_close_cb(NULL, NULL, NULL);
 }
 
@@ -142,7 +142,7 @@ void test_update_available_1() {
   mock_fdo_notifications_send_action(mock_notifications, data->uid,
                                      "app.show-updates");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file); // delete desktop file
   g_assert_cmpstr(result, ==, "show-updates");
 }
@@ -173,7 +173,7 @@ void test_update_available_2() {
 
   mock_fdo_notifications_send_action(mock_notifications, data->uid, "default");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file); // delete desktop file
   g_assert_cmpstr(result, ==, "show-updates");
 }
@@ -226,7 +226,7 @@ void test_update_available_3() {
                               (GCallback)test_ignore_event_cb, &signal_counter);
 
   // run the test
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file); // delete desktop file
   g_signal_handler_disconnect(notifier, sid);
 
@@ -275,7 +275,7 @@ void test_update_available_4() {
   mock_fdo_notifications_send_action(mock_notifications, data->uid,
                                      "app.ignore-notification");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   unlink(desktop_file2); // delete desktop file
   g_signal_handler_disconnect(notifier, sid);
@@ -329,7 +329,7 @@ void test_update_available_5() {
   mock_fdo_notifications_send_action(mock_notifications, data->uid,
                                      "app.ignore-notification");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   unlink(desktop_file2); // delete desktop file
   unlink(desktop_file3); // delete desktop file
@@ -388,7 +388,7 @@ void test_update_available_6() {
   mock_fdo_notifications_send_action(mock_notifications, data->uid,
                                      "app.ignore-notification");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   unlink(desktop_file2); // delete desktop file
   unlink(desktop_file3); // delete desktop file
@@ -418,7 +418,7 @@ void test_update_available_7() {
 
   mock_fdo_notifications_send_action(mock_notifications, data->uid, "default");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   g_autofree gchar *expected =
       g_strdup_printf("app-launch-updated %s", desktop_file1);
@@ -449,7 +449,7 @@ void test_update_available_8() {
 
   mock_fdo_notifications_send_action(mock_notifications, data->uid, "default");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   g_assert_cmpstr(result, ==, "show-updates");
 }
@@ -477,7 +477,7 @@ void test_update_available_9() {
   g_assert_true(has_action(data->actions, "app.show-updates", "Show updates"));
 
   mock_fdo_notifications_send_action(mock_notifications, data->uid, "default");
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   g_assert_cmpstr(result, ==, "show-updates");
 }
@@ -516,7 +516,7 @@ void test_update_available_10() {
   mock_fdo_notifications_send_action(mock_notifications, data->uid,
                                      "app.ignore-notification");
 
-  g_autofree gchar *result = wait_for_notification_close(NULL, NULL);
+  g_autofree gchar *result = wait_for_notification_close();
   unlink(desktop_file1); // delete desktop file
   g_signal_handler_disconnect(notifier, sid);
   g_assert_cmpstr(result, ==, "ignore-snaps");

--- a/tests/test-sdi-progress-dock.c
+++ b/tests/test-sdi-progress-dock.c
@@ -41,7 +41,7 @@ static void wait_for_events(guint timeout, guint changes) {
 
 // these are the actual tests
 
-static void test_progress_bar() {
+static void test_progress_bar(void) {
   g_assert_false(updating_value);
   g_assert_false(progress_visible_value);
   g_assert_cmpfloat_with_epsilon(progress_value, -1.0, DBL_EPSILON);
@@ -68,7 +68,7 @@ static void test_progress_bar() {
   g_assert_cmpfloat_with_epsilon(progress_value, 10 / 10.0, DBL_EPSILON);
 }
 
-static void test_updating() {
+static void test_updating(void) {
   g_assert_true(updating_value);
   g_assert_true(progress_visible_value);
 

--- a/tests/test-sdi-progress-window.c
+++ b/tests/test-sdi-progress-window.c
@@ -52,7 +52,7 @@ static void show_progress_window(gchar *snap_name, gchar *desktop_file) {
  * This is done inside Gtk itself, thus ensuring that the desired
  * widgets have been created.
  */
-static int count_progress_childs() {
+static int count_progress_childs(void) {
   GtkWindow *window =
       GTK_WINDOW(sdi_progress_window_get_window(progress_window));
   // to differentiate between window existing and zero elements, and no window
@@ -140,7 +140,7 @@ static GtkWidget *find_progress_by_description(const gchar *program_name) {
   return NULL;
 }
 
-static int count_hash_childs() {
+static int count_hash_childs(void) {
   GHashTable *table = sdi_progress_window_get_dialogs(progress_window);
   g_assert_nonnull(table);
   return g_hash_table_size(table);
@@ -205,7 +205,7 @@ typedef enum {
  * 3: any of the progress status elements is not visible
  * 4: all the elements are visible
  */
-static VisibilityLevel check_full_visibility() {
+static VisibilityLevel check_full_visibility(void) {
   GtkWindow *window =
       GTK_WINDOW(sdi_progress_window_get_window(progress_window));
   // to differentiate between window existing and zero elements, and no window
@@ -323,7 +323,7 @@ static bool press_hide_button(GtkWidget *element) {
 
 // these are the actual tests
 
-static void test_progress_bar() {
+static void test_progress_bar(void) {
   g_assert_cmpint(count_hash_childs(), ==, 0);
   g_assert_cmpint(count_progress_childs(), ==, -1);
 
@@ -361,7 +361,7 @@ static void test_progress_bar() {
   g_assert_cmpint(check_widgets_visibility(element), ==, ALL_BUT_ICON_VISIBLE);
 }
 
-static void test_pulse_bar() {
+static void test_pulse_bar(void) {
   g_assert_cmpint(count_hash_childs(), ==, 1);
   g_assert_cmpint(count_progress_childs(), ==, 1);
 
@@ -382,7 +382,7 @@ static void test_pulse_bar() {
   g_assert_cmpint(check_widgets_visibility(element), ==, ALL_BUT_ICON_VISIBLE);
 }
 
-static void test_close_bar() {
+static void test_close_bar(void) {
   GtkWidget *element = find_progress_by_description("KiCad-no-icon");
   g_assert_nonnull(element);
 
@@ -395,7 +395,7 @@ static void test_close_bar() {
   g_assert_cmpint(count_progress_childs(), ==, -1);
 }
 
-static void test_manual_hide() {
+static void test_manual_hide(void) {
   show_progress_window("B-SNAP", *(app_list + 1));
 
   GtkWidget *element = find_progress_by_description("Document Scanner");
@@ -413,7 +413,7 @@ static void test_manual_hide() {
   g_assert_cmpint(count_progress_childs(), ==, -1);
 }
 
-static void test_dual_progress_bar1() {
+static void test_dual_progress_bar1(void) {
   show_progress_window("C-SNAP", *(app_list));
   g_assert_cmpint(count_hash_childs(), ==, 1);
   g_assert_cmpint(count_progress_childs(), ==, 1);
@@ -439,7 +439,7 @@ static void test_dual_progress_bar1() {
   g_assert_cmpint(check_widgets_visibility(element), ==, ALL_BUT_ICON_VISIBLE);
 }
 
-static void test_dual_progress_bar2() {
+static void test_dual_progress_bar2(void) {
   show_progress_window("D-SNAP", *(app_list + 1));
   g_assert_cmpint(count_hash_childs(), ==, 2);
   g_assert_cmpint(count_progress_childs(), ==, 2);
@@ -489,7 +489,7 @@ static void test_dual_progress_bar2() {
   g_assert_cmpint(check_widgets_visibility(element2), ==, ALL_VISIBLE);
 }
 
-static void test_dual_progress_bar3() {
+static void test_dual_progress_bar3(void) {
   sdi_progress_window_end_refresh(progress_window, "C-SNAP");
   g_assert_cmpint(count_hash_childs(), ==, 1);
   g_assert_cmpint(count_progress_childs(), ==, 1);
@@ -502,7 +502,7 @@ static void test_dual_progress_bar3() {
   g_assert_cmpint(check_widgets_visibility(element), ==, ALL_VISIBLE);
 }
 
-static void test_dual_progress_bar4() {
+static void test_dual_progress_bar4(void) {
   sdi_progress_window_end_refresh(progress_window, "D-SNAP");
   g_assert_cmpint(count_hash_childs(), ==, 0);
   g_assert_cmpint(count_progress_childs(), ==, -1);
@@ -538,12 +538,12 @@ static void do_activate(GApplication *app, gpointer data) {
   g_application_release(app);
 }
 
-static gchar *get_data_path() {
+static gchar *get_data_path(void) {
   g_autofree gchar *path = g_test_build_filename(G_TEST_BUILT, "data", NULL);
   return g_canonicalize_filename(path, NULL);
 }
 
-void set_environment() {
+void set_environment(void) {
   g_autofree gchar *share_path = get_data_path();
   g_autofree gchar *newvar = g_strdup_printf("%s:/usr/share/", share_path);
   g_setenv("XDG_DATA_DIRS", newvar, TRUE);

--- a/tests/test-snapd-desktop-integration.c
+++ b/tests/test-snapd-desktop-integration.c
@@ -229,7 +229,7 @@ static gboolean setup_session_bus(GError **error) {
   return TRUE;
 }
 
-static gboolean launch_snapd_desktop_integration() {
+static gboolean launch_snapd_desktop_integration(void) {
   g_autoptr(GSubprocessLauncher) launcher =
       g_subprocess_launcher_new(G_SUBPROCESS_FLAGS_NONE);
   g_subprocess_launcher_setenv(launcher, "LC_ALL", "C", TRUE);
@@ -434,7 +434,7 @@ void timeout_no_install(GMainLoop *loop) {
   g_main_loop_quit(loop);
 }
 
-static void set_test_settings() {
+static void set_test_settings(void) {
   set_setting("org.gnome.desktop.interface", "gtk-theme", "GtkTheme1");
   set_setting("org.gnome.desktop.interface", "icon-theme", "IconTheme1");
   set_setting("org.gnome.desktop.interface", "cursor-theme", "CursorTheme1");


### PR DESCRIPTION
Some tests fail to build because some NULL parameters were being passed to functions without parameters. By default, GCC presumes that a function declared with `()` has an indeterminate number of parameters, while to specify that it has no parameters it has to be declared with `(void)`.

This has been fixed by removing the unneeded NULLs, and also "void" has been added to all the functions without parameters, to ensure that a compile error is always triggered if a parameters is passed to these functions.